### PR TITLE
Build oolite again

### DIFF
--- a/oolite-config/build.sh
+++ b/oolite-config/build.sh
@@ -20,6 +20,10 @@ git fetch --unshallow
 git stash
 git revert --no-commit 0031890efd38021567d4d5a4d28b1418a34768d1
 
+# Comment out Windows version checks in /mingw64/include/wingdi.h
+sed -i '2396 s|^|//|' /mingw64/include/wingdi.h
+sed -i '2447 s|^|//|' /mingw64/include/wingdi.h
+
 # Add -fobjc-exceptions and -fcommon to OBJC flags in GNUMakefile, line 36
 # Since gcc 10 -fno-common is default; add -fcommon to avoid 9425 (yes, 9425!) errors of the form
 # C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/13.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: ./obj.win.spk/oolite.obj/OODebugSupport.m.o:C:\msys64\home\Robert\oolite/src/Core/OOOpenGLExtensionManager.h:280: multiple definition of `glClampColor'; ./obj.win.spk/oolite.obj/OODebugMonitor.m.o:C:\msys64\home\Robert\oolite/src/Core/OOOpenGLExtensionManager.h:280: first defined here


### PR DESCRIPTION
## Build Oolite again!

### Pull Request Type

- [x] Bug Fix
- [ ] Documentation Update
- [ ] Dependency Update
- [ ] New Feature

### Description

Reverts commit [https://github.com/OoliteProject/oolite/commit/0031890efd38021567d4d5a4d28b1418a34768d1#diff-e3445fc75aa9c3e4a60fbe5394dcce12693022018216a8fbe0000fe9952850a6](https://github.com/OoliteProject/oolite/commit/0031890efd38021567d4d5a4d28b1418a34768d1#diff-e3445fc75aa9c3e4a60fbe5394dcce12693022018216a8fbe0000fe9952850a6)
as I currently can't build it on MSYS2. I will need to work this out later.

Also removes the check on Windows versions in the wingdi.h header.
### Checklist

- [ ] Tests have been added or updated to cover the changes made in this pull request.
- [ ] Documentation has been updated to reflect the changes made in this pull request.
- [ ] Code follows the project's coding conventions and style guidelines.
- [ ] All automated tests pass successfully.
- [ ] Updates to the build process have been applied to both the GHA workflow and the from-fresh bash script.

### Related Issues

Please list any related issues or pull requests that are addressed by this pull request.

### Additional Notes

Add any additional notes or context about this pull request here.
