### PR TITLE
Remove dep tests

### DIFF
--- a/.github/workflows/build-oolite.yml
+++ b/.github/workflows/build-oolite.yml
@@ -384,66 +384,6 @@ jobs:
 ########################################
 ########################################
 
-# Test the dependencies.
-# These jobs only run if the build jobs have been successful and the run_tests input is true.
-
-  test-libs-base:
-    name: Test libs-base
-    runs-on: windows-latest
-    if: ${{ inputs.run_tests }}
-    needs: [build-tools-make, build-libs-base]
-    defaults:
-      run:
-        shell: msys2 {0}
-
-    steps:
-      - name: Checkout this repository
-        uses: actions/checkout@v6
-
-      - name: Set up msys2
-        uses: ./.github/actions/start-msys2-with-deps
-        with:
-          deps_path: deps/libs-base/msys2-deps
-
-      - name: Install built version of tools-make from cache
-        uses: ./.github/actions/install-built-dependency
-        with:
-          name: tools-make
-          path: tools-make
-          key: cache-tools-make-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/tools-make/*') }}
-          install_script: ./deps/tools-make/install.sh
-
-      - name: Install built version of libs-base from cache
-        uses: ./.github/actions/install-built-dependency
-        with:
-          name: libs-base
-          path: libs-base
-          key: cache-libs-base-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/libs-base/*', '**/deps/tools-make/*') }}
-          install_script: ./deps/libs-base/install.sh
-
-      - name: Test libs-base
-        run: |
-          . /mingw64/share/GNUstep/Makefiles/GNUstep.sh
-          cd libs-base
-          # Guard against nproc failing
-          num_jobs=$(nproc 2>/dev/null)
-          if [ -z "$num_jobs" ]; then
-            echo "Warning: Could not determine number of processors, using 1 job"
-            num_jobs=1
-          fi
-          make -j"$num_jobs" check
-
-      - name: Upload tests.log
-        uses: actions/upload-artifact@v6
-        with:
-          name: libs-base_test.log
-          path: |
-            libs-base/Tests/tests.log
-
-########################################
-########################################
-########################################
-
 # Clear unnecessary Oolite caches on GitHub
 
 # The Oolite caches are only intended to be used in the current workflow run.

--- a/.github/workflows/build-oolite.yml
+++ b/.github/workflows/build-oolite.yml
@@ -441,50 +441,6 @@ jobs:
             libs-base/Tests/tests.log
 
 ########################################
-
-  test-sdl:
-    name: Test SDL
-    runs-on: windows-latest
-    if: ${{ inputs.run_tests }}
-    needs: [build-sdl]
-    defaults:
-      run:
-        shell: msys2 {0}
-    strategy:
-      matrix:
-        msystem: [MINGW64, CLANG64]
-      fail-fast: false
-
-    steps:
-      - name: Checkout this repository
-        uses: actions/checkout@v6
-
-      - name: Set up msys2
-        uses: ./.github/actions/start-msys2-with-deps
-        with:
-          deps_path: deps/sdl/msys2-deps-${{ matrix.msystem }}
-
-      - name: Install built version of SDL from cache
-        uses: ./.github/actions/install-built-dependency
-        with:
-          name: SDL
-          path: SDL-1.2.13
-          key: cache-sdl-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/sdl/*') }}-${{ matrix.msystem }}
-          install_script: ./deps/sdl/install.sh
-
-      - name: Build SDL tests
-        run: |
-          cd SDL-1.2.13/test
-          ./configure
-          # Guard against nproc failing
-          num_jobs=$(nproc 2>/dev/null)
-          if [ -z "$num_jobs" ]; then
-            echo "Warning: Could not determine number of processors, using 1 job"
-            num_jobs=1
-          fi
-          make -j"$num_jobs" check
-
-########################################
 ########################################
 ########################################
 

--- a/.github/workflows/build-oolite.yml
+++ b/.github/workflows/build-oolite.yml
@@ -14,8 +14,6 @@
 # - build-tools-make: This job checks out the tools-make repository, compiles tools-make, and caches the build.
 # - build-libs-base: This job checks out the libs-base repository, compiles libs-base, and caches the build.
 # - build-sdl: This job downloads and compiles SDL, and caches the build.
-# - test-libs-base: This job uses the cache from the successful build-libs-base job and runs the tests on the built library.
-# - test-sdl: This job uses the cache from the successful build-sdl job and runs the tests on the built library
 # - clear-oolite-caches: This job deletes any caches created by the build-oolite job.
 # - build-oolite-from-fresh-msys2-mingw64: This job is a single script to build Oolite from scratch. It is used to test the from-fresh script.
 # - generate-pdfs: This job generates the PDFs of the Oolite documentation .odt files in the oolite/Doc/ folder.
@@ -25,11 +23,6 @@ name: Build Oolite on MSYS2 environments
 on: 
   workflow_call:
     inputs:
-      run_tests:
-        description: Run build tests
-        required: true
-        type: boolean
-        default: false
       from_fresh:
         description: Build all dependencies from scratch
         required: true
@@ -42,11 +35,6 @@ on:
         default: master
   workflow_dispatch:
     inputs:
-      run_tests:
-        description: Run build tests
-        required: true
-        type: boolean
-        default: false
       from_fresh:
         description: Build all dependencies from scratch
         required: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,17 +3,12 @@
 # This workflow is triggered on pushes to the main branch and pull requests, as well as manually via the GitHub Actions UI. 
 # It calls both the test-repo and build-oolite workflows.
 # If it is triggered by a workflow_dispatch event, it will pass those parameters to the build-oolite workflow.
-# Otherwise, it calls the build-oolite workflow with inputs to compile Oolite from the master branch, without running tests, and using pre-existing caches if available.
+# Otherwise, it calls the build-oolite workflow with inputs to compile Oolite from the master branch, using pre-existing caches if available.
 
 name: CI
 on: 
   workflow_dispatch:
     inputs:
-      run_tests:
-        description: Run build tests
-        required: false
-        type: boolean
-        default: false
       from_fresh:
         description: Build all dependencies from scratch
         required: false
@@ -47,7 +42,6 @@ jobs:
       actions: write
     uses: ./.github/workflows/build-oolite.yml
     with:
-      run_tests: ${{ inputs.run_tests || false }}
       from_fresh: ${{ inputs.from_fresh || false }}
       oolite_ref: ${{ inputs.oolite_ref || 'master' }}
 

--- a/.github/workflows/schedule-oolite-build.yml
+++ b/.github/workflows/schedule-oolite-build.yml
@@ -53,7 +53,6 @@ jobs:
     if: ${{ needs.check-recent-oolite-commits.outputs.has_commits == 'true' }}
     uses: ./.github/workflows/build-oolite.yml
     with:
-      run_tests: false
       from_fresh: false
       oolite_ref: master
 


### PR DESCRIPTION
## Stop testing libs-base and SDL

### Pull Request Type

- [x] Dependency Update

### Description

Stop testing the builds of libs-base and SDL. These are rarely used, the SDL tests only check if the tests compile as we cannot actually run them and they have stopped working when the Clang build was added, and the libs-base tests take a long time to run and don't provide useful information.

### Related Issues

Closes #97
